### PR TITLE
Add theme toggle for Christmas and road trip themes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,21 +2,26 @@ import React, { useEffect, useState } from 'react';
 import { 
   finalArray,
   christmasStyleMap,
-  christmasWordArrays
+  christmasWordArrays,
+  roadTripStyleMap,
+  roadTripWords
 } from './BingoArray';
 import Square from './Square';
 import ToggleButton from './ToggleButton';
 import './index.css';
 import './App.css';
 
-function checkForBackgroundStyle(item) {
+function checkForBackgroundStyle(item, selectedTheme) {
+  const styleMap = selectedTheme === 'christmas' ? christmasStyleMap : roadTripStyleMap;
+  const wordArrays = selectedTheme === 'christmas' ? christmasWordArrays : { roadTrip: roadTripWords };
+
   if (item.includes('Free Space')) {
-    return christmasStyleMap['Free Space'];
+    return styleMap['Free Space'];
   }
 
-  for (const [key, value] of Object.entries(christmasStyleMap)) {
+  for (const [key, value] of Object.entries(styleMap)) {
     if (key === 'Free Space') continue; // Skip 'Free Space' as it's already checked
-    if (christmasWordArrays[key] && christmasWordArrays[key].includes(item)) {
+    if (wordArrays[key] && wordArrays[key].includes(item)) {
       return value;
     }
   }
@@ -31,6 +36,8 @@ function toTitleCase(str) {
 
 function App() {
     const [isToggled, setIsToggled] = useState(false);
+    const [selectedTheme, setSelectedTheme] = useState('christmas');
+
     // Update the Square-selected class when isToggled changes
     useEffect(() => {
       const styleElement = document.createElement('style');
@@ -64,12 +71,23 @@ function App() {
         setIsToggled(newToggleState);
     };
 
+    const handleThemeChange = (event) => {
+        setSelectedTheme(event.target.value);
+    };
+
     return (
         <div className={`App ${isToggled ? "dark-mode" : ""}`}>
             <div className="App-header">(Christmas Bingo)</div>
+            <div>
+                <label htmlFor="theme-select">Choose a theme:</label>
+                <select id="theme-select" value={selectedTheme} onChange={handleThemeChange}>
+                    <option value="christmas">Christmas</option>
+                    <option value="roadTrip">Road Trip</option>
+                </select>
+            </div>
             <div className="grid-5-by-5">
                 {finalArray.map((item, index) => {
-                  let passedClass = checkForBackgroundStyle(item);
+                  let passedClass = checkForBackgroundStyle(item, selectedTheme);
                   const titleCaseItem = toTitleCase(item);
                   if (isToggled) {
                     passedClass += " is-toggled";

--- a/src/BingoArray.js
+++ b/src/BingoArray.js
@@ -148,3 +148,5 @@ function shuffle(array) {
 const shuffledArray = shuffle(bingoArrayLarge);
 export const finalArray = shuffledArray.slice(0, 24);
 finalArray.splice(12, 0, "Free Space");
+
+export { roadTripWords };

--- a/src/BingoArray.js
+++ b/src/BingoArray.js
@@ -149,4 +149,4 @@ const shuffledArray = shuffle(bingoArrayLarge);
 export const finalArray = shuffledArray.slice(0, 24);
 finalArray.splice(12, 0, "Free Space");
 
-export { roadTripWords };
+export { roadTripWords, roadTripStyleMap };

--- a/src/BingoArray.js
+++ b/src/BingoArray.js
@@ -1,5 +1,3 @@
-// Export a const that returns a shuffled array of bingo words
-
 const lightsWords = [
   'Reindeer lights',
   'Snowman lights',
@@ -60,6 +58,33 @@ const misc = [
   'Peace sign',
 ];
 
+const roadTripWords = [
+  'Gas station',
+  'Rest area',
+  'Scenic view',
+  'Road sign',
+  'Toll booth',
+  'Highway',
+  'Exit sign',
+  'Mile marker',
+  'Overpass',
+  'Underpass',
+  'Billboard',
+  'Rest stop',
+  'Truck stop',
+  'Welcome center',
+  'Tourist attraction',
+  'State line',
+  'City limit',
+  'Speed limit sign',
+  'Construction zone',
+  'Detour',
+  'Traffic light',
+  'Roundabout',
+  'Pedestrian crossing',
+  'Bicycle lane',
+];
+
 export const christmasWordArrays = {
   lights: lightsWords,
   blowUp: blowUpWords,
@@ -75,9 +100,37 @@ export const christmasStyleMap = {
   walmartPurchase: 'walmart'
 };
 
+export const roadTripStyleMap = {
+  'Free Space': 'free-space Square-selected',
+  gasStation: 'gas-station',
+  restArea: 'rest-area',
+  scenicView: 'scenic-view',
+  roadSign: 'road-sign',
+  tollBooth: 'toll-booth',
+  highway: 'highway',
+  exitSign: 'exit-sign',
+  mileMarker: 'mile-marker',
+  overpass: 'overpass',
+  underpass: 'underpass',
+  billboard: 'billboard',
+  restStop: 'rest-stop',
+  truckStop: 'truck-stop',
+  welcomeCenter: 'welcome-center',
+  touristAttraction: 'tourist-attraction',
+  stateLine: 'state-line',
+  cityLimit: 'city-limit',
+  speedLimitSign: 'speed-limit-sign',
+  constructionZone: 'construction-zone',
+  detour: 'detour',
+  trafficLight: 'traffic-light',
+  roundabout: 'roundabout',
+  pedestrianCrossing: 'pedestrian-crossing',
+  bicycleLane: 'bicycle-lane',
+};
+
 export const bingoArrayLarge = `
    ${christmasWordArrays.blowUp}, ${christmasWordArrays.lights}, ${christmasWordArrays.house},
-   ${christmasWordArrays.walmartPurchase}, ${misc}`
+   ${christmasWordArrays.walmartPurchase}, ${misc}, ${roadTripWords}`
    .split(',').map(item => item.trim());
 
 function shuffle(array) {
@@ -95,5 +148,3 @@ function shuffle(array) {
 const shuffledArray = shuffle(bingoArrayLarge);
 export const finalArray = shuffledArray.slice(0, 24);
 finalArray.splice(12, 0, "Free Space");
-
-

--- a/src/Square.js
+++ b/src/Square.js
@@ -41,7 +41,6 @@ function checkForWin(found, itemKey) {
 }
 
 function Square(props) {
-  // console.log(props);
   const [found, setFound] = useToggle(false);
   return (
     <div 


### PR DESCRIPTION
Add functionality to switch between Christmas and Road Trip themes in the bingo game.

* **BingoArray.js**
  - Add a new set of words for the road trip theme.
  - Define a new style map for the road trip theme.
  - Update the `finalArray` to include the road trip words.

* **App.js**
  - Import the road trip style map and word arrays.
  - Add a state variable to manage the selected theme.
  - Update the `checkForBackgroundStyle` function to handle the road trip theme.
  - Add a dropdown for theme selection in the `return` statement.

* **Square.js**
  - Remove commented-out console log statement.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kdv24/xmas-bingo-22/pull/1?shareId=0f67a05d-635e-4a20-9d3b-edde601118e5).