### PR TITLE
Add eurovision theme

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -140,6 +140,32 @@ body {
   background-color: #9faa68; /* P0cab */
 }
 
+/* Eurovision Styles */
+.eurovision {
+  position: relative;
+  background-image: linear-gradient(#1E90FF, #00BFFF, #87CEFA);
+}
+
+.stage {
+  position: relative;
+  background-color: #FFD700; /* Gold */
+}
+
+.artist {
+  position: relative;
+  background-color: #FF69B4; /* Hot Pink */
+}
+
+.song {
+  position: relative;
+  background-color: #8A2BE2; /* Blue Violet */
+}
+
+.country {
+  position: relative;
+  background-color: #32CD32; /* Lime Green */
+}
+
 /* Toggle Slider */
 /* The switch - the box around the slider */
 .switch {

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,8 @@ import {
   christmasWordArrays,
   roadTripWordArrays,
   roadTripStyleMap,
+  eurovisionWordArrays,
+  eurovisionStyleMap,
   getWordsForTheme,
   shuffle
 } from './BingoArray';
@@ -13,8 +15,8 @@ import './index.css';
 import './App.css';
 
 function checkForBackgroundStyle(item, theme) {
-  const styleMap = theme === 'Christmas' ? christmasStyleMap : roadTripStyleMap;
-  const wordArrays = theme === 'Christmas' ? christmasWordArrays : roadTripWordArrays;
+  const styleMap = theme === 'Christmas' ? christmasStyleMap : theme === 'Road Trip' ? roadTripStyleMap : eurovisionStyleMap;
+  const wordArrays = theme === 'Christmas' ? christmasWordArrays : theme === 'Road Trip' ? roadTripWordArrays : eurovisionWordArrays;
 
   if (item.includes('Free Space')) {
     return styleMap['Free Space'];
@@ -96,12 +98,14 @@ function App() {
       const appDiv = document.getElementsByClassName('App')[0];
       if (theme === 'Christmas') {
         appDiv.classList.add('christmas');
-      } else {
+      } else if (theme === 'Road Trip') {
         appDiv.classList.add('road-trip');
+      } else {
+        appDiv.classList.add('eurovision');
       }
     });
     return (
-        <div className={`App ${theme === 'Road Trip' ? "road-trip" : "christmas"}`}>
+        <div className={`App ${theme === 'Road Trip' ? "road-trip" : theme === 'Eurovision' ? "eurovision" : "christmas"}`}>
             <div className="App-header">{theme} Bingo</div>
             <div className="theme-dropdown-container">
                 <label>
@@ -109,6 +113,7 @@ function App() {
                     <select className="theme-dropdown" value={theme} onChange={handleThemeChange}>
                         <option value="Christmas">Christmas</option>
                         <option value="Road Trip">Road Trip</option>
+                        <option value="Eurovision">Eurovision</option>
                     </select>
                 </label>
             </div>

--- a/src/BingoArray.js
+++ b/src/BingoArray.js
@@ -140,8 +140,59 @@ export const roadTripStyleMap = {
   roadsideAttraction: 'roadside-attraction'
 };
 
+const stageWords = [
+  'Main stage',
+  'Backup dancers',
+  'Pyrotechnics',
+  'LED screens',
+  'Stage props',
+  'Lighting effects',
+];
+
+const artistWords = [
+  'Lead singer',
+  'Backup singers',
+  'Costume change',
+  'Dance routine',
+  'Special guest',
+  'Vocal effects',
+];
+
+const songWords = [
+  'Eurovision song',
+  'Chorus',
+  'Verse',
+  'Bridge',
+  'Key change',
+  'High note',
+];
+
+const countryWords = [
+  'Host country',
+  'Participating country',
+  'Flag',
+  'National costume',
+  'Traditional instrument',
+  'Cultural reference',
+];
+
+export const eurovisionWordArrays = {
+  stage: stageWords,
+  artist: artistWords,
+  song: songWords,
+  country: countryWords
+};
+
+export const eurovisionStyleMap = {
+  'Free Space': 'free-space Square-selected',
+  stage: 'stage',
+  artist: 'artist',
+  song: 'song',
+  country: 'country'
+};
+
 export function getWordsForTheme(theme) {
-  const wordArrays = theme === 'Christmas' ? christmasWordArrays : roadTripWordArrays;
+  const wordArrays = theme === 'Christmas' ? christmasWordArrays : theme === 'Road Trip' ? roadTripWordArrays : eurovisionWordArrays;
   const allWords = Object.values(wordArrays).flat();
   return allWords;
 }


### PR DESCRIPTION
Add a eurovision theme following the same pattern as the road trip and christmas themes.

* **src/App.js**
  - Add eurovision theme to `checkForBackgroundStyle` function.
  - Add eurovision theme to `useEffect` hook that sets the `finalArray` state.
  - Add eurovision theme to the `theme-dropdown` select options.

* **src/App.css**
  - Add styles for the eurovision theme.
  - Add styles for the eurovision theme categories.

* **src/BingoArray.js**
  - Add word arrays for the eurovision theme categories.
  - Add style map for the eurovision theme categories.
  - Update the `getWordsForTheme` function to include the eurovision theme.

