### PR TITLE
Update free space class in custom themes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -70,6 +70,12 @@ body {
   color: #146B38;
 }
 
+.free-space {
+  background-image: linear-gradient(#146B38, #146B38);
+  font-weight: 200;
+  color: #146B38;
+}
+
 /* Christmas Styles */
 .christmas {
   position: relative;

--- a/src/BingoArray.js
+++ b/src/BingoArray.js
@@ -62,7 +62,7 @@ export const christmasWordArrays = {
 };
 
 export const christmasStyleMap = {
-  'Free Space': 'free-space Square-selected',
+  'Free Space': 'free-space',
   lights: 'lights',
   yardDecorations: 'yard-decorations',
   holidaySymbols: 'holiday-symbols',
@@ -129,7 +129,7 @@ export const roadTripWordArrays = {
 };
 
 export const roadTripStyleMap = {
-  'Free Space': 'free-space Square-selected',
+  'Free Space': 'free-space',
   gasStation: 'gas-station',
   restArea: 'rest-area',
   scenicOverlook: 'scenic-overlook',
@@ -196,7 +196,7 @@ export const planeTripWordArrays = {
 };
 
 export const planeTripStyleMap = {
-  'Free Space': 'free-space Square-selected',
+  'Free Space': 'free-space',
   airport: 'airport',
   inFlight: 'in-flight',
   destination: 'destination',
@@ -271,7 +271,7 @@ export const eurovisionWordArrays = {
 };
 
 export const eurovisionStyleMap = {
-  'Free Space': 'free-space Square-selected',
+  'Free Space': 'free-space',
   stage: 'stage',
   artist: 'artist',
   song: 'song',

--- a/src/Square.js
+++ b/src/Square.js
@@ -66,7 +66,11 @@ function Square(props) {
       }
     }
     >
-      {props.item}
+      {props.item === "Free Space" ? (
+        <div className="free-space">{props.item}</div>
+      ) : (
+        props.item
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Update the code to apply the 'free-space' class to the free space square in custom themes.

* **CSS Changes**
  - Add a new `.free-space` class in `src/App.css` with the same styles as `.Square-selected`.

* **BingoArray.js Changes**
  - Update `christmasStyleMap`, `roadTripStyleMap`, `planeTripStyleMap`, and `eurovisionStyleMap` to use the new `.free-space` class for the free space.

* **Square.js Changes**
  - Update the `Square` component to apply the `.free-space` class when the item is "Free Space".

