### PR TITLE
Only switch the word arrays to lower case and title case for the current pre-made themes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -56,15 +56,18 @@ function checkForBackgroundStyle(item, theme) {
   return '';
 }
 
-function toTitleCase(str) {
-   return str.toLowerCase().split(" ").map(word => {
-    if (word === "atm") {
-      return word.toUpperCase();
-    }
-    else {
-      return word.charAt(0).toUpperCase() + word.slice(1);
-    }
-   }).join(" ");
+function toTitleCase(str, theme) {
+  if (['Christmas', 'Road Trip', 'Plane Travel', 'Eurovision'].includes(theme)) {
+    return str.toLowerCase().split(" ").map(word => {
+      if (word === "atm") {
+        return word.toUpperCase();
+      }
+      else {
+        return word.charAt(0).toUpperCase() + word.slice(1);
+      }
+    }).join(" ");
+  }
+  return str;
 }
 
 function App() {
@@ -221,7 +224,7 @@ function App() {
             <div className="grid-5-by-5">
                 {finalArray.map((item, index) => {
                   let passedClass = checkForBackgroundStyle(item, theme);
-                  const titleCaseItem = toTitleCase(item);
+                  const titleCaseItem = toTitleCase(item, theme);
                   if (isToggled) {
                     passedClass += " is-toggled";
                 }


### PR DESCRIPTION
Update the `toTitleCase` function and its usage to handle pre-made themes differently from custom themes.

* Modify the `toTitleCase` function to only apply to pre-made themes and return the string as is for custom themes.
* Update the `toTitleCase` function call in the `App` component to pass the theme name as a parameter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kdv24/xmas-bingo-22/pull/15?shareId=ea2687e3-a6b9-46f4-b6e3-36198a5d365e).