### PR TITLE
Make the Create a New Theme div a modal with a backdrop

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -330,3 +330,27 @@ input:checked + .slider::before {
   background-repeat: no-repeat;
   background-size: cover, contain;
 }
+
+/* Modal and Backdrop Styles */
+.modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 80%;
+  max-width: 500px;
+  background-color: white;
+  padding: 20px;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 999;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import Modal from 'react-modal';
 import { 
   christmasStyleMap,
   christmasWordArrays,
@@ -77,6 +78,7 @@ function App() {
     const [foundArray, setFoundArray] = useState([12]);
     const [customThemes, setCustomThemes] = useState([]);
     const [showThemeCreator, setShowThemeCreator] = useState(false);
+    const [isModalOpen, setIsModalOpen] = useState(false);
 
     // Update the Square-selected class when isToggled changes
     useEffect(() => {
@@ -125,6 +127,7 @@ function App() {
         const selectedTheme = event.target.value;
         if (selectedTheme === "Create a new theme") {
             setShowThemeCreator(true);
+            setIsModalOpen(true);
         } else {
             setTheme(selectedTheme);
             setFinalArray([]); // Reset the board when the theme changes
@@ -146,6 +149,11 @@ function App() {
 
         setCustomThemes([...customThemes, newTheme]);
         setShowThemeCreator(false);
+        setIsModalOpen(false);
+    };
+
+    const closeModal = () => {
+        setIsModalOpen(false);
     };
 
     useEffect(() => {
@@ -220,7 +228,16 @@ function App() {
                     </select>
                 </label>
             </div>
-            {showThemeCreator && <ThemeCreator onSave={handleSaveTheme} />}
+            <Modal
+                isOpen={isModalOpen}
+                onRequestClose={closeModal}
+                contentLabel="Create a New Theme"
+                className="modal"
+                overlayClassName="overlay"
+            >
+                <ThemeCreator onSave={handleSaveTheme} />
+                <button onClick={closeModal}>Close</button>
+            </Modal>
             <div className="grid-5-by-5">
                 {finalArray.map((item, index) => {
                   let passedClass = checkForBackgroundStyle(item, theme);

--- a/src/ThemeCreator.js
+++ b/src/ThemeCreator.js
@@ -30,7 +30,7 @@ const ThemeCreator = ({ onSave }) => {
   }, [themeName, wordArrays, backgroundColor]);
 
   return (
-    <div>
+    <div className="modal-content">
       <h2>Create a New Theme</h2>
       <div>
         <label>Theme Name:</label>
@@ -57,6 +57,7 @@ const ThemeCreator = ({ onSave }) => {
         />
       </div>
       <button onClick={handleSave}>Save Theme</button>
+      <button onClick={() => onSave(null)}>Close</button>
     </div>
   );
 };


### PR DESCRIPTION
Convert the "Create a New Theme" div into a modal with a backdrop that covers the current window and add styling for the modal content.

* Import `Modal` from `react-modal` in `src/App.js`.
* Add `Modal` component to render the "Create a New Theme" div as a modal in `src/App.js`.
* Add state management for showing and hiding the modal in `src/App.js`.
* Add a close button to the modal content in `src/App.js`.
* Add styling for the modal content in `src/ThemeCreator.js`.
* Add a close button to the modal content in `src/ThemeCreator.js`.
* Add CSS styles for the modal and backdrop in `src/App.css`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kdv24/xmas-bingo-22/pull/16?shareId=7f94f8a0-758f-4037-967e-d035b983e5b1).