### PR TITLE
Fix bingo page layout and confetti background

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root" style="width: -webkit-fill-available; background-image: linear-gradient(#2E8B57, #3CB371, #66CDAA);"></div>
+    <div id="root" style="width: 100%; background-image: linear-gradient(#2E8B57, #3CB371, #66CDAA);"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/App.css
+++ b/src/App.css
@@ -335,6 +335,7 @@ input:checked + .slider::before {
   background-image: url('https://www.transparenttextures.com/patterns/confetti.png');
   background-repeat: repeat;
   background-size: auto;
+  background-position: center;
 }
 
 /* Modal and Backdrop Styles */

--- a/src/App.js
+++ b/src/App.js
@@ -188,10 +188,12 @@ function App() {
           if (backgroundColor) {
             // Set the background image to a linear gradient of the background color.
             appDiv.style.setProperty('background-image', `linear-gradient(${backgroundColor}, ${backgroundColor}, ${backgroundColor})`);
+            appDiv.style.setProperty('background-position', 'center'); // Ensure the background is centered
           } else {
             console.log('No custom background color found in localStorage');
             // Setting a default color
             appDiv.style.setProperty('background-image', 'linear-gradient(purple, purple, purple)');
+            appDiv.style.setProperty('background-position', 'center'); // Ensure the background is centered
           }          
           break;
       }

--- a/src/Square.js
+++ b/src/Square.js
@@ -142,6 +142,7 @@ function Square(props) {
         setFound(!found);
         checkForWin(!found, props.itemKey, props.theme, props.foundArray);
       }}
+      style={{ backgroundPosition: 'center' }} // Ensure the background is centered
     >
         {props.item}
     </div>


### PR DESCRIPTION
Fix the bingo page layout and confetti background positioning.

* **public/index.html**
  - Change the `div` with id `root` to set its width to `100%` instead of `-webkit-fill-available`.

* **src/App.js**
  - Set the background position to `center` in the `App` component to ensure the confetti background is centered.

* **src/Square.js**
  - Set the background position to `center` in the `Square` component to ensure the confetti background is centered.

* **src/App.css**
  - Set the background position to `center` in the `confetti-background` class to ensure the background is centered.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kdv24/xmas-bingo-22/pull/22?shareId=ba66f17d-6b6c-400b-8a1f-686906867a05).