### PR TITLE
Fix background update when a square is unselected

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -251,6 +251,7 @@ function App() {
                       isToggled={isToggled}
                       theme={theme}
                       foundArray={foundArray}
+                      setFoundArray={setFoundArray}
                     />
                   );
                 })}

--- a/src/Square.js
+++ b/src/Square.js
@@ -39,6 +39,8 @@ function checkForWin(found, itemKey, theme, foundArray) {
     foundArray.splice(foundIndex, 1);
   }
 
+  let isWinning = false;
+
   winningSets.forEach((winningSet) => {
     let count = 0;
     winningSet.forEach((winningItem) => {
@@ -47,6 +49,7 @@ function checkForWin(found, itemKey, theme, foundArray) {
       }
     });
     if (count >= 5) {
+      isWinning = true;
       const appDiv = document.getElementsByClassName('App')[0];
       console.log('theme in checking for win: ', theme)
       if (theme !== 'Christmas' && theme !== 'Road Trip' && theme !== 'Plane Travel' && theme !== 'Eurovision') {
@@ -70,7 +73,35 @@ function checkForWin(found, itemKey, theme, foundArray) {
           break;
       }
     }
-  })
+  });
+
+  if (!isWinning) {
+    const appDiv = document.getElementsByClassName('App')[0];
+    appDiv.classList.remove('confetti', 'snow', 'national-park', 'clouds', 'eurovision-background');
+    switch (theme) {
+      case 'Christmas':
+        appDiv.classList.add('christmas');
+        break;
+      case 'Road Trip':
+        appDiv.classList.add('road-trip');
+        break;
+      case 'Plane Travel':
+        appDiv.classList.add('plane-travel');
+        break;
+      case 'Eurovision':
+        appDiv.classList.add('eurovision');
+        break;
+      default:
+        appDiv.classList.add('custom-theme');
+        let backgroundColor = localStorage.getItem('customThemeBackground');
+        if (backgroundColor) {
+          appDiv.style.setProperty('background-image', `linear-gradient(${backgroundColor}, ${backgroundColor}, ${backgroundColor})`);
+        } else {
+          appDiv.style.setProperty('background-image', 'linear-gradient(purple, purple, purple)');
+        }
+        break;
+    }
+  }
 }
 
 function Square(props) {


### PR DESCRIPTION
Update `checkForWin` function to handle unselecting a square and reverting the background to the non-winning state.

* Add `isWinning` variable to track if the current state is a winning state.
* Update the background to the non-winning state if `isWinning` is false.
* Remove winning background classes and add the appropriate non-winning background class based on the theme.
* Handle custom theme background color from local storage if applicable.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kdv24/xmas-bingo-22/pull/25?shareId=0dfec551-56bd-4b5f-9717-a06b4d7679f0).