### PR TITLE
Add delete functionality for custom themes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -78,6 +78,8 @@ function App() {
     const [foundArray, setFoundArray] = useState([12]);
     const [customThemes, setCustomThemes] = useState([]);
     const [isModalOpen, setIsModalOpen] = useState(false);
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const [themeToDelete, setThemeToDelete] = useState('');
 
     // Update the Square-selected class when isToggled changes
     useEffect(() => {
@@ -126,6 +128,8 @@ function App() {
         const selectedTheme = event.target.value;
         if (selectedTheme === "Create a new theme") {
             setIsModalOpen(true);
+        } else if (selectedTheme === "Delete a theme") {
+            setIsDeleteModalOpen(true);
         } else {
             setTheme(selectedTheme);
             setFinalArray([]); // Reset the board when the theme changes
@@ -155,10 +159,15 @@ function App() {
         setIsModalOpen(false);
     };
 
-    const deleteTheme = async (themeName) => {
-        const updatedThemes = customThemes.filter(theme => theme.themeName !== themeName);
+    const closeDeleteModal = () => {
+        setIsDeleteModalOpen(false);
+    };
+
+    const handleDeleteTheme = async () => {
+        const updatedThemes = customThemes.filter(theme => theme.themeName !== themeToDelete);
         setCustomThemes(updatedThemes);
         // Add code to delete the theme from Google Sheets here
+        setIsDeleteModalOpen(false);
     };
 
     useEffect(() => {
@@ -231,10 +240,8 @@ function App() {
                             </option>
                         ))}
                         <option value="Create a new theme">Create a new theme</option>
+                        <option value="Delete a theme">Delete a theme</option>
                     </select>
-                    {customThemes.map((customTheme, index) => (
-                        <button key={index} onClick={() => deleteTheme(customTheme.themeName)}>x</button>
-                    ))}
                 </label>
             </div>
             <Modal
@@ -247,6 +254,31 @@ function App() {
             >
                 <ThemeCreator onSave={handleSaveTheme} />
                 <button onClick={closeModal}>Cancel</button>
+            </Modal>
+            <Modal
+                appElement={document.getElementById('root')}
+                isOpen={isDeleteModalOpen}
+                onRequestClose={closeDeleteModal}
+                contentLabel="Delete a Theme"
+                className="modal"
+                overlayClassName="overlay"
+            >
+                <div className="modal-content">
+                    <h2 className="modal-title">Delete a Theme</h2>
+                    <div className="modal-section">
+                        <label>Select Theme to Delete:</label>
+                        <select value={themeToDelete} onChange={(e) => setThemeToDelete(e.target.value)}>
+                            <option value="">Select a theme</option>
+                            {customThemes.map((customTheme, index) => (
+                                <option key={index} value={customTheme.themeName}>
+                                    {customTheme.themeName}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    <button className="modal-button" onClick={handleDeleteTheme}>Delete Theme</button>
+                    <button className="modal-button" onClick={closeDeleteModal}>Cancel</button>
+                </div>
             </Modal>
             <div className="grid-5-by-5">
                 {finalArray.map((item, index) => {

--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ import {
 import Square from './Square';
 import ToggleButton from './ToggleButton';
 import ThemeCreator from './ThemeCreator';
+import DeleteThemeModal from './DeleteThemeModal';
 import './index.css';
 import './App.css';
 
@@ -255,31 +256,14 @@ function App() {
                 <ThemeCreator onSave={handleSaveTheme} />
                 <button onClick={closeModal}>Cancel</button>
             </Modal>
-            <Modal
-                appElement={document.getElementById('root')}
+            <DeleteThemeModal
                 isOpen={isDeleteModalOpen}
                 onRequestClose={closeDeleteModal}
-                contentLabel="Delete a Theme"
-                className="modal"
-                overlayClassName="overlay"
-            >
-                <div className="modal-content">
-                    <h2 className="modal-title">Delete a Theme</h2>
-                    <div className="modal-section">
-                        <label>Select Theme to Delete:</label>
-                        <select value={themeToDelete} onChange={(e) => setThemeToDelete(e.target.value)}>
-                            <option value="">Select a theme</option>
-                            {customThemes.map((customTheme, index) => (
-                                <option key={index} value={customTheme.themeName}>
-                                    {customTheme.themeName}
-                                </option>
-                            ))}
-                        </select>
-                    </div>
-                    <button className="modal-button" onClick={handleDeleteTheme}>Delete Theme</button>
-                    <button className="modal-button" onClick={closeDeleteModal}>Cancel</button>
-                </div>
-            </Modal>
+                customThemes={customThemes}
+                themeToDelete={themeToDelete}
+                setThemeToDelete={setThemeToDelete}
+                handleDeleteTheme={handleDeleteTheme}
+            />
             <div className="grid-5-by-5">
                 {finalArray.map((item, index) => {
                   let passedClass = checkForBackgroundStyle(item, theme);

--- a/src/App.js
+++ b/src/App.js
@@ -228,11 +228,13 @@ function App() {
                         {customThemes.map((customTheme, index) => (
                             <option key={index} value={customTheme.themeName}>
                                 {customTheme.themeName}
-                                <span onClick={() => deleteTheme(customTheme.themeName)}> x</span>
                             </option>
                         ))}
                         <option value="Create a new theme">Create a new theme</option>
                     </select>
+                    {customThemes.map((customTheme, index) => (
+                        <button key={index} onClick={() => deleteTheme(customTheme.themeName)}>x</button>
+                    ))}
                 </label>
             </div>
             <Modal

--- a/src/App.js
+++ b/src/App.js
@@ -155,6 +155,12 @@ function App() {
         setIsModalOpen(false);
     };
 
+    const deleteTheme = async (themeName) => {
+        const updatedThemes = customThemes.filter(theme => theme.themeName !== themeName);
+        setCustomThemes(updatedThemes);
+        // Add code to delete the theme from Google Sheets here
+    };
+
     useEffect(() => {
       const appDiv = document.getElementsByClassName('App')[0];
       switch (theme) {
@@ -220,7 +226,10 @@ function App() {
                         <option value="Plane Travel">Plane Travel</option>
                         <option value="Eurovision">Eurovision</option>
                         {customThemes.map((customTheme, index) => (
-                            <option key={index} value={customTheme.themeName}>{customTheme.themeName}</option>
+                            <option key={index} value={customTheme.themeName}>
+                                {customTheme.themeName}
+                                <span onClick={() => deleteTheme(customTheme.themeName)}> x</span>
+                            </option>
                         ))}
                         <option value="Create a new theme">Create a new theme</option>
                     </select>

--- a/src/App.js
+++ b/src/App.js
@@ -164,10 +164,41 @@ function App() {
         setIsDeleteModalOpen(false);
     };
 
+    const deleteFromGoogleSheet = async (themeName) => {
+      const scriptURL = 'https://script.google.com/macros/s/AKfycbxb2QVElxoPiELzifG-Qt-pSNjN8pJPulJv6ADf19AZLZ2IZrs_6DR6MYhxmtUQ-AYU/exec';
+      const formData = new FormData();
+      formData.append('themeName', themeName);
+  
+      try {
+        const response = await fetch(scriptURL, {
+          method: 'DELETE',
+          body: formData,
+        });
+  
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+  
+        const result = await response.json();
+        console.log('Success:', result);
+      } catch (error) {
+        console.error('Error:', error);
+      }
+    };
+
+
+    const deleteThemeFromLocalStorage = (themeName) => {
+      const storedThemes = JSON.parse(localStorage.getItem('customThemes')) || [];
+      const updatedThemes = storedThemes.filter(theme => theme.themeName !== themeName);
+      localStorage.setItem('customThemes', JSON.stringify(updatedThemes));
+    };
+
     const handleDeleteTheme = async () => {
         const updatedThemes = customThemes.filter(theme => theme.themeName !== themeToDelete);
         setCustomThemes(updatedThemes);
-        // Add code to delete the theme from Google Sheets here
+        // Code to delete the theme from Google Sheets 
+        deleteFromGoogleSheet(themeToDelete);
+        deleteThemeFromLocalStorage(themeToDelete);
         setIsDeleteModalOpen(false);
         if (theme === themeToDelete) {
             setTheme('Christmas');

--- a/src/App.js
+++ b/src/App.js
@@ -169,6 +169,9 @@ function App() {
         setCustomThemes(updatedThemes);
         // Add code to delete the theme from Google Sheets here
         setIsDeleteModalOpen(false);
+        if (theme === themeToDelete) {
+            setTheme('Christmas');
+        }
     };
 
     useEffect(() => {

--- a/src/DeleteThemeModal.js
+++ b/src/DeleteThemeModal.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import Modal from 'react-modal';
+
+const DeleteThemeModal = ({ isOpen, onRequestClose, customThemes, themeToDelete, setThemeToDelete, handleDeleteTheme }) => {
+  return (
+    <Modal
+      appElement={document.getElementById('root')}
+      isOpen={isOpen}
+      onRequestClose={onRequestClose}
+      contentLabel="Delete a Theme"
+      className="modal"
+      overlayClassName="overlay"
+    >
+      <div className="modal-content">
+        <h2 className="modal-title">Delete a Theme</h2>
+        <div className="modal-section">
+          <label>Select Theme to Delete:</label>
+          <select value={themeToDelete} onChange={(e) => setThemeToDelete(e.target.value)}>
+            <option value="">Select a theme</option>
+            {customThemes.map((customTheme, index) => (
+              <option key={index} value={customTheme.themeName}>
+                {customTheme.themeName}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button className="modal-button" onClick={handleDeleteTheme}>Delete Theme</button>
+        <button className="modal-button" onClick={onRequestClose}>Cancel</button>
+      </div>
+    </Modal>
+  );
+};
+
+export default DeleteThemeModal;

--- a/src/ThemeCreator.js
+++ b/src/ThemeCreator.js
@@ -30,6 +30,28 @@ const ThemeCreator = ({ onSave }) => {
     }
   };
 
+  const deleteFromGoogleSheet = async (themeName) => {
+    const scriptURL = 'https://script.google.com/macros/s/AKfycbxb2QVElxoPiELzifG-Qt-pSNjN8pJPulJv6ADf19AZLZ2IZrs_6DR6MYhxmtUQ-AYU/exec';
+    const formData = new FormData();
+    formData.append('themeName', themeName);
+
+    try {
+      const response = await fetch(scriptURL, {
+        method: 'DELETE',
+        body: formData,
+      });
+
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+
+      const result = await response.json();
+      console.log('Success:', result);
+    } catch (error) {
+      console.error('Error:', error);
+    }
+  };
+
   const handleSave = async () => {
     const newTheme = {
       themeName,
@@ -39,6 +61,12 @@ const ThemeCreator = ({ onSave }) => {
     await saveCustomTheme(newTheme, backgroundColor);
     await onSave(newTheme);
     await saveToGoogleSheet(newTheme);
+  };
+
+  const deleteThemeFromLocalStorage = (themeName) => {
+    const storedThemes = JSON.parse(localStorage.getItem('customThemes')) || [];
+    const updatedThemes = storedThemes.filter(theme => theme.themeName !== themeName);
+    localStorage.setItem('customThemes', JSON.stringify(updatedThemes));
   };
 
   useEffect(() => {

--- a/src/ThemeCreator.js
+++ b/src/ThemeCreator.js
@@ -30,27 +30,27 @@ const ThemeCreator = ({ onSave }) => {
     }
   };
 
-  const deleteFromGoogleSheet = async (themeName) => {
-    const scriptURL = 'https://script.google.com/macros/s/AKfycbxb2QVElxoPiELzifG-Qt-pSNjN8pJPulJv6ADf19AZLZ2IZrs_6DR6MYhxmtUQ-AYU/exec';
-    const formData = new FormData();
-    formData.append('themeName', themeName);
+  // const deleteFromGoogleSheet = async (themeName) => {
+  //   const scriptURL = 'https://script.google.com/macros/s/AKfycbxb2QVElxoPiELzifG-Qt-pSNjN8pJPulJv6ADf19AZLZ2IZrs_6DR6MYhxmtUQ-AYU/exec';
+  //   const formData = new FormData();
+  //   formData.append('themeName', themeName);
 
-    try {
-      const response = await fetch(scriptURL, {
-        method: 'DELETE',
-        body: formData,
-      });
+  //   try {
+  //     const response = await fetch(scriptURL, {
+  //       method: 'DELETE',
+  //       body: formData,
+  //     });
 
-      if (!response.ok) {
-        throw new Error('Network response was not ok');
-      }
+  //     if (!response.ok) {
+  //       throw new Error('Network response was not ok');
+  //     }
 
-      const result = await response.json();
-      console.log('Success:', result);
-    } catch (error) {
-      console.error('Error:', error);
-    }
-  };
+  //     const result = await response.json();
+  //     console.log('Success:', result);
+  //   } catch (error) {
+  //     console.error('Error:', error);
+  //   }
+  // };
 
   const handleSave = async () => {
     const newTheme = {
@@ -63,11 +63,11 @@ const ThemeCreator = ({ onSave }) => {
     await saveToGoogleSheet(newTheme);
   };
 
-  const deleteThemeFromLocalStorage = (themeName) => {
-    const storedThemes = JSON.parse(localStorage.getItem('customThemes')) || [];
-    const updatedThemes = storedThemes.filter(theme => theme.themeName !== themeName);
-    localStorage.setItem('customThemes', JSON.stringify(updatedThemes));
-  };
+  // const deleteThemeFromLocalStorage = (themeName) => {
+  //   const storedThemes = JSON.parse(localStorage.getItem('customThemes')) || [];
+  //   const updatedThemes = storedThemes.filter(theme => theme.themeName !== themeName);
+  //   localStorage.setItem('customThemes', JSON.stringify(updatedThemes));
+  // };
 
   useEffect(() => {
     const storedThemes = JSON.parse(localStorage.getItem('customThemes')) || [];


### PR DESCRIPTION
Add a small 'x' to the right side of each item in the dropdown that is a custom theme and enable deletion of the theme and its corresponding Google Sheets entry when the 'x' is clicked.

* **App.js**
  - Add a `deleteTheme` function to handle the deletion of themes from the custom themes list.
  - Update the dropdown to include a small 'x' next to each custom theme item.
  - Add an onClick handler to the 'x' to call the `deleteTheme` function.

* **ThemeCreator.js**
  - Add a `deleteFromGoogleSheet` function to delete a theme from Google Sheets.
  - Add a `deleteThemeFromLocalStorage` function to delete a theme from local storage.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kdv24/xmas-bingo-22/pull/28?shareId=a117f8a5-b597-477d-a342-3dcfbbd47743).