### PR TITLE
Fix theme reset when deleting current theme

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -71,6 +71,12 @@ function toTitleCase(str, theme) {
   return str;
 }
 
+function resetBackground() {
+  const appDiv = document.getElementsByClassName('App')[0];
+  appDiv.classList.remove('snow', 'national-park', 'clouds', 'eurovision-background', 'confetti');
+  appDiv.style.removeProperty('background-image');
+}
+
 function App() {
     const [isToggled, setIsToggled] = useState(false);
     const [theme, setTheme] = useState('Christmas');
@@ -130,8 +136,7 @@ function App() {
             setTheme(selectedTheme);
             setFinalArray([]); // Reset the board when the theme changes
             setFoundArray([12]); // Reset the foundArray when the theme changes
-            const appDiv = document.getElementsByClassName('App')[0];
-            appDiv.style.removeProperty('background-image'); // Reset the background color when switching to a non-custom theme
+            resetBackground();
         }
     };
 

--- a/src/Square.js
+++ b/src/Square.js
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from "react";
-
+import { resetBackground } from './App'; // P5f14
 
 const winningSets = [
   [0, 1, 2, 3, 4],
@@ -68,6 +68,8 @@ function checkForWin(found, itemKey, theme, foundArray) {
         default:
           break;
       }
+    } else {
+      resetBackground(); // P0655
     }
   })
 }


### PR DESCRIPTION
Add a function to reset the background when the theme is applied and call it in relevant functions.

* **App.js**
  - Add `resetBackground` function to reset the background.
  - Call `resetBackground` in `handleThemeChange` function.

* **Square.js**
  - Import `resetBackground` from `App.js`.
  - Call `resetBackground` in `checkForWin` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kdv24/xmas-bingo-22/pull/29?shareId=d66cbaac-d824-467a-bf20-cb41f7f77eab).