### PR TITLE
Add selected square color to custom themes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -137,6 +137,21 @@ function App() {
             setFoundArray([12]); // Reset the foundArray when the theme changes
             const appDiv = document.getElementsByClassName('App')[0];
             appDiv.style.removeProperty('background-image'); // Reset the background color when switching to a non-custom theme
+            if (selectedTheme !== 'Christmas' && selectedTheme !== 'Road Trip' && selectedTheme !== 'Plane Travel' && selectedTheme !== 'Eurovision') {
+              let customThemes = JSON.parse(localStorage.getItem('customThemes')) || [];
+              let customTheme = customThemes.find(t => t.themeName === selectedTheme);
+              let selectedSquareColor = customTheme ? customTheme.selectedSquareColor : null;
+              if (selectedSquareColor) {
+                const styleElement = document.createElement('style');
+                styleElement.id = "dynamic-style";
+                styleElement.innerHTML = `
+                  .Square-selected {
+                    background-color: ${selectedSquareColor} !important;
+                  }
+                `;
+                document.head.appendChild(styleElement);
+              }
+            }
         }
     };
 
@@ -244,6 +259,7 @@ function App() {
           let customThemes = JSON.parse(localStorage.getItem('customThemes')) || [];
           let customTheme = customThemes.find(t => t.themeName === theme);
           let backgroundColor = customTheme ? customTheme.backgroundColor : null;
+          let selectedSquareColor = customTheme ? customTheme.selectedSquareColor : null;
           
           // Check if backgroundColor is not null or undefined
           if (backgroundColor) {
@@ -252,6 +268,18 @@ function App() {
           } else {
             // Setting a default color
             appDiv.style.setProperty('background-image', 'linear-gradient(purple, purple, purple)');
+          }
+
+          // Check if selectedSquareColor is not null or undefined
+          if (selectedSquareColor) {
+            const styleElement = document.createElement('style');
+            styleElement.id = "dynamic-style";
+            styleElement.innerHTML = `
+              .Square-selected {
+                background-color: ${selectedSquareColor} !important;
+              }
+            `;
+            document.head.appendChild(styleElement);
           }          
           break;
       }

--- a/src/ThemeCreator.js
+++ b/src/ThemeCreator.js
@@ -5,6 +5,7 @@ const ThemeCreator = ({ onSave }) => {
   const [themeName, setThemeName] = useState('');
   const [wordArrays, setWordArrays] = useState('');
   const [backgroundColor, setBackgroundColor] = useState('');
+  const [selectedSquareColor, setSelectedSquareColor] = useState('');
 
   const saveToGoogleSheet = async (themeData) => {
     const scriptURL = 'https://script.google.com/macros/s/AKfycbxb2QVElxoPiELzifG-Qt-pSNjN8pJPulJv6ADf19AZLZ2IZrs_6DR6MYhxmtUQ-AYU/exec';
@@ -12,6 +13,7 @@ const ThemeCreator = ({ onSave }) => {
     formData.append('themeName', themeData.themeName);
     formData.append('wordArrays', themeData.wordArrays.join(', '));
     formData.append('backgroundColor', themeData.backgroundColor);
+    formData.append('selectedSquareColor', themeData.selectedSquareColor);
 
     try {
       const response = await fetch(scriptURL, {
@@ -34,7 +36,8 @@ const ThemeCreator = ({ onSave }) => {
     const newTheme = {
       themeName,
       wordArrays: wordArrays.split(',').map(word => word.trim()),
-      backgroundColor: backgroundColor
+      backgroundColor: backgroundColor,
+      selectedSquareColor: selectedSquareColor
     };
     await saveCustomTheme(newTheme, backgroundColor);
     await onSave(newTheme);
@@ -47,11 +50,12 @@ const ThemeCreator = ({ onSave }) => {
       const newTheme = {
         themeName,
         wordArrays: wordArrays.split(',').map(word => word.trim()),
-        backgroundColor: backgroundColor
+        backgroundColor: backgroundColor,
+        selectedSquareColor: selectedSquareColor
       };
       localStorage.setItem('customThemes', JSON.stringify([...storedThemes, newTheme]));
     }
-  }, [themeName, wordArrays, backgroundColor]);
+  }, [themeName, wordArrays, backgroundColor, selectedSquareColor]);
 
   return (
     <div className="modal-content">
@@ -79,6 +83,14 @@ const ThemeCreator = ({ onSave }) => {
           type="text"
           value={backgroundColor}
           onChange={(e) => setBackgroundColor(e.target.value)}
+        />
+      </div>
+      <div className="modal-section selected-square-color">
+        <label>Selected square color by name or&nbsp; <a href="https://htmlcolorcodes.com/">#hexcode</a>:</label>
+        <input
+          type="text"
+          value={selectedSquareColor}
+          onChange={(e) => setSelectedSquareColor(e.target.value)}
         />
       </div>
       <button className="modal-button" onClick={handleSave}>Save Theme</button>


### PR DESCRIPTION
Add a new input field for the selected square color in the theme creator and update related functions to handle the new field.

* **ThemeCreator.js**
  - Add a new input field for the selected square color below the background color input field.
  - Update the `handleSave` function to include the selected square color in the new theme object.
  - Update the `saveToGoogleSheet` function to include the selected square color in the form data.

* **App.js**
  - Update the `handleThemeChange` function to apply the selected square color to the custom theme.
  - Update the `useEffect` hook that sets the custom theme background to also set the selected square color.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kdv24/xmas-bingo-22/pull/35?shareId=c55da25a-21af-4c3b-bf46-caa832a09cba).